### PR TITLE
specify official jenkins container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins
+FROM jenkinsci/jenkins
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Jenkins Docker image to use easily with volume mounts
 If JENKINS_HOME is owned by root, then change it to jenkins user before starting Jenkins.
 
 Otherwise start normally.
+
+Unless otherwise set with -e, JENKINS_HOME will be /var/jenkins_home.


### PR DESCRIPTION
Using the container referenced on https://jenkins-ci.org/ which is at version 1.644 (website lists 1.645 as current as of this commit) vs the _/jenkins container which is version 1.625.3.
